### PR TITLE
Remove `Warning : load_model does not return...`

### DIFF
--- a/fastlangid/langid.py
+++ b/fastlangid/langid.py
@@ -6,6 +6,8 @@ import collections
 from fasttext import load_model
 import fasttext
 
+
+fasttext.FastText.eprint = lambda x: None
 if sys.version_info[0] >= 3:
     unicode = str
 


### PR DESCRIPTION
They just deleted eprint method but seems like they won't update fasttext

(commit: https://github.com/facebookresearch/fastText/commit/9ef22d9fac33c84480fa2e4edf56df13cb0bcfbb)